### PR TITLE
重构Service接口，参数增加ServiceContext

### DIFF
--- a/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceActor.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceActor.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.ly.train.flower.common.service.Aggregate;
+import com.ly.train.flower.common.service.Complete;
 import com.ly.train.flower.common.service.FlowerService;
 import com.ly.train.flower.common.service.Service;
 import com.ly.train.flower.common.service.ServiceConstants;
@@ -21,8 +22,8 @@ import com.ly.train.flower.common.service.message.DefaultMessage;
 import com.ly.train.flower.common.service.message.FirstMessage;
 import com.ly.train.flower.common.service.message.FlowMessage;
 import com.ly.train.flower.common.service.message.ReturnMessage;
-import com.ly.train.flower.common.service.web.Complete;
 import com.ly.train.flower.common.service.web.Flush;
+import com.ly.train.flower.common.service.web.HttpComplete;
 import com.ly.train.flower.common.service.web.Web;
 
 import akka.actor.ActorRef;
@@ -157,7 +158,7 @@ public class ServiceActor extends UntypedActor {
       if (service instanceof Flush) {
         web.flush();
       }
-      if (service instanceof Complete) {
+      if (service instanceof HttpComplete) {
         web.complete();
       }
     }

--- a/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceActor.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceActor.java
@@ -142,20 +142,22 @@ public class ServiceActor extends UntypedActor {
       o = ((Service) service).process(fm.getMessage(), context);
     } catch (Exception e) {
       Web web = context.getWeb();
+      FlowContext.removeServiceContext(fm.getTransactionId());
       if (web != null) {
-        FlowContext.removeServiceContext(fm.getTransactionId());
         web.complete();
       }
       throw e;
     }
 
     Web web = context.getWeb();
+    if (service instanceof Complete) {
+      FlowContext.removeServiceContext(fm.getTransactionId());
+    }
     if (web != null) {
       if (service instanceof Flush) {
         web.flush();
       }
       if (service instanceof Complete) {
-        FlowContext.removeServiceContext(fm.getTransactionId());
         web.complete();
       }
     }

--- a/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceActor.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceActor.java
@@ -158,7 +158,7 @@ public class ServiceActor extends UntypedActor {
       if (service instanceof Flush) {
         web.flush();
       }
-      if (service instanceof HttpComplete) {
+      if (service instanceof HttpComplete || service instanceof Complete) {
         web.complete();
       }
     }

--- a/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceFacade.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceFacade.java
@@ -18,7 +18,7 @@ import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 public class ServiceFacade {
-  // TODO user define
+  // TODO user define duration
   public static FiniteDuration duration = Duration.create(3, SECONDS);
 
   public static void asyncCallService(String flowName, String serviceName, Object o,
@@ -26,7 +26,6 @@ public class ServiceFacade {
     FlowMessage flowMessage = ServiceUtil.buildFlowMessage(o);
     ServiceUtil.makeWebContext(flowMessage, ctx);
     ServiceActorFactory.buildServiceActor(flowName, serviceName).tell(flowMessage, null);
-
   }
 
   public static void asyncCallService(String flowName, String serviceName, Object o)

--- a/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceUtil.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/actor/ServiceUtil.java
@@ -20,12 +20,11 @@ public class ServiceUtil {
   }
 
   public static void makeWebContext(FlowMessage flowMessage, AsyncContext ctx) throws IOException {
-    if (ctx == null) {
-      return;
-    }
     ServiceContext serviceContext = new ServiceContext();
-    Web web = new Web(ctx);
-    serviceContext.setWeb(web);
+    if (ctx != null) {
+      Web web = new Web(ctx);
+      serviceContext.setWeb(web);
+    }
     FlowContext.putServiceContext(flowMessage.getTransactionId(), serviceContext);
   }
 

--- a/flower.common/src/main/java/com/ly/train/flower/common/service/AggregateService.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/service/AggregateService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.ly.train.flower.common.service.containe.ServiceContext;
 import com.ly.train.flower.common.service.message.FlowMessage;
 
 public class AggregateService implements Service, Aggregate {
@@ -17,7 +18,7 @@ public class AggregateService implements Service, Aggregate {
   Map<String, Integer> resultNumberMap = new ConcurrentHashMap<String, Integer>();
 
   @Override
-  public Object process(Object message) {
+  public Object process(Object message, ServiceContext context) {
 
     FlowMessage flowMessage = (FlowMessage) message;
 

--- a/flower.common/src/main/java/com/ly/train/flower/common/service/Complete.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/service/Complete.java
@@ -1,0 +1,5 @@
+package com.ly.train.flower.common.service;
+
+public interface Complete {
+
+}

--- a/flower.common/src/main/java/com/ly/train/flower/common/service/ConditionService.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/service/ConditionService.java
@@ -1,5 +1,6 @@
 package com.ly.train.flower.common.service;
 
+import com.ly.train.flower.common.service.containe.ServiceContext;
 import com.ly.train.flower.common.service.message.Condition;
 
 public class ConditionService implements Service<Condition> {
@@ -11,7 +12,7 @@ public class ConditionService implements Service<Condition> {
   }
 
   @Override
-  public Object process(Condition message) {
+  public Object process(Condition message, ServiceContext context) {
     Object o = message.getCondition();
     if (o instanceof Boolean) {
       if ((Boolean) o == true) {

--- a/flower.common/src/main/java/com/ly/train/flower/common/service/HttpService.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/service/HttpService.java
@@ -1,7 +1,0 @@
-package com.ly.train.flower.common.service;
-
-import com.ly.train.flower.common.service.web.Web;
-
-public interface HttpService<T> extends FlowerService {
-  Object process(T message, Web web) throws Exception;
-}

--- a/flower.common/src/main/java/com/ly/train/flower/common/service/NothingService.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/service/NothingService.java
@@ -1,9 +1,11 @@
 package com.ly.train.flower.common.service;
 
+import com.ly.train.flower.common.service.containe.ServiceContext;
+
 public class NothingService implements Service {
 
   @Override
-  public Object process(Object message) {
+  public Object process(Object message, ServiceContext context) {
     return null;
   }
 

--- a/flower.common/src/main/java/com/ly/train/flower/common/service/Service.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/service/Service.java
@@ -1,6 +1,8 @@
 package com.ly.train.flower.common.service;
 
+import com.ly.train.flower.common.service.containe.ServiceContext;
+
 public interface Service<T> extends FlowerService {
 
-  Object process(T message) throws Throwable;
+  Object process(T message, ServiceContext context) throws Throwable;
 }

--- a/flower.common/src/main/java/com/ly/train/flower/common/service/containe/ServiceContext.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/service/containe/ServiceContext.java
@@ -24,4 +24,8 @@ public class ServiceContext {
   public Object get(Object key) {
     return map.get(key);
   }
+  
+  public void remove(Object key) {
+    map.remove(key);
+  }
 }

--- a/flower.common/src/main/java/com/ly/train/flower/common/service/containe/ServiceContext.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/service/containe/ServiceContext.java
@@ -1,8 +1,12 @@
 package com.ly.train.flower.common.service.containe;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import com.ly.train.flower.common.service.web.Web;
 
 public class ServiceContext {
+  private Map<Object, Object> map = new ConcurrentHashMap<Object, Object>();
   private Web web;
 
   public Web getWeb() {
@@ -13,4 +17,11 @@ public class ServiceContext {
     this.web = web;
   }
 
+  public void put(Object key, Object value) {
+    map.put(key, value);
+  }
+
+  public Object get(Object key) {
+    return map.get(key);
+  }
 }

--- a/flower.common/src/main/java/com/ly/train/flower/common/service/web/HttpComplete.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/service/web/HttpComplete.java
@@ -1,5 +1,5 @@
 package com.ly.train.flower.common.service.web;
 
-public interface Complete {
+public interface HttpComplete {
 
 }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/Supervisor/Service1.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/Supervisor/Service1.java
@@ -1,13 +1,13 @@
 package com.ly.train.flower.common.sample.Supervisor;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class Service1 implements Service {
 
-
   @Override
-  public Object process(Object message) {
-    return ((Message1)message).getM2();
+  public Object process(Object message, ServiceContext context) {
+    return ((Message1) message).getM2();
   }
 
 }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/Supervisor/Service2.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/Supervisor/Service2.java
@@ -1,6 +1,8 @@
 package com.ly.train.flower.common.sample.Supervisor;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
+
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -8,7 +10,7 @@ import java.io.File;
 public class Service2 implements Service<Message2> {
 
   @Override
-  public Object process(Message2 message) throws Throwable {
+  public Object process(Message2 message, ServiceContext context) throws Throwable {
 
     File file = new File("test.file");
     if (!file.exists()) {

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/Supervisor/Service3.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/Supervisor/Service3.java
@@ -1,18 +1,19 @@
 package com.ly.train.flower.common.sample.Supervisor;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class Service3 implements Service<Message2> {
 
   @Override
-  public Object process(Message2 message) throws Throwable {
-//    File file = new File("/Users/yang/tmp/test.file");
-//    if (!file.exists()) {
-//      FileUtils.write(file, "111", "UTF-8");
-//      throw new Exception("Service3");
-//    } else {
-//      FileUtils.deleteQuietly(file);
-//    }
+  public Object process(Message2 message, ServiceContext context) throws Throwable {
+    // File file = new File("/Users/yang/tmp/test.file");
+    // if (!file.exists()) {
+    // FileUtils.write(file, "111", "UTF-8");
+    // throw new Exception("Service3");
+    // } else {
+    // FileUtils.deleteQuietly(file);
+    // }
     return message.getName().toUpperCase();
   }
 

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/Supervisor/Service4.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/Supervisor/Service4.java
@@ -1,13 +1,14 @@
 package com.ly.train.flower.common.sample.Supervisor;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 import java.util.Set;
 
 public class Service4 implements Service<Set> {
 
   @Override
-  public Object process(Set message) {
+  public Object process(Set message, ServiceContext context) {
     Message2 m = new Message2();
     for (Object o : message) {
 
@@ -21,8 +22,8 @@ public class Service4 implements Service<Set> {
     Message3 m3 = new Message3();
     m3.setM2(m);
     // pi();
-    //sleep();
-    //System.out.println(System.currentTimeMillis());
+    // sleep();
+    // System.out.println(System.currentTimeMillis());
     return m3;
   }
 

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceA.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceA.java
@@ -1,11 +1,12 @@
 package com.ly.train.flower.common.sample.condition;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceA implements Service<String> {
 
   @Override
-  public Object process(String message) {
+  public Object process(String message, ServiceContext context) {
     if ("b".equals(message)) {
       return new MessageB();
     }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceB.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceB.java
@@ -1,11 +1,12 @@
 package com.ly.train.flower.common.sample.condition;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceB implements Service<MessageB> {
 
   @Override
-  public Object process(MessageB message) {
+  public Object process(MessageB message, ServiceContext context) {
     System.out.println("I am Service B.");
     return null;
   }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceC.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceC.java
@@ -1,6 +1,7 @@
 package com.ly.train.flower.common.sample.condition;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceC implements Service<MessageC> {
 
@@ -8,7 +9,7 @@ public class ServiceC implements Service<MessageC> {
   /**
    * print service
    */
-  public Object process(MessageC message) {
+  public Object process(MessageC message, ServiceContext context) {
     System.out.println("I am Service C.");
     MessageX mx = new MessageX();
     mx.setCondition("serviceE,serviceD");

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceD.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceD.java
@@ -1,11 +1,12 @@
 package com.ly.train.flower.common.sample.condition;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceD implements Service {
 
   @Override
-  public Object process(Object message) {
+  public Object process(Object message, ServiceContext context) {
     System.out.println("I am Service D.");
     return null;
   }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceE.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceE.java
@@ -1,11 +1,12 @@
 package com.ly.train.flower.common.sample.condition;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceE implements Service {
 
   @Override
-  public Object process(Object message) {
+  public Object process(Object message, ServiceContext context) {
     System.out.println("I am Service E.");
     MessageX x = new MessageX();
     x.setCondition(1);

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceF.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceF.java
@@ -1,11 +1,12 @@
 package com.ly.train.flower.common.sample.condition;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceF implements Service {
 
   @Override
-  public Object process(Object message) {
+  public Object process(Object message, ServiceContext context) {
     System.out.println("I am Service F.");
     return null;
   }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceG.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/condition/ServiceG.java
@@ -1,11 +1,12 @@
 package com.ly.train.flower.common.sample.condition;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceG implements Service {
 
   @Override
-  public Object process(Object message) {
+  public Object process(Object message, ServiceContext context) {
     System.out.println("I am Service G.");
     return null;
   }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/programflow/ServiceA.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/programflow/ServiceA.java
@@ -1,6 +1,7 @@
 package com.ly.train.flower.common.sample.programflow;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceA implements Service<String> {
 
@@ -14,14 +15,12 @@ public class ServiceA implements Service<String> {
   /**
    * trim service
    */
-  public Object process(String message) {
+  public Object process(String message, ServiceContext context) {
     ca.f();
     if (message != null && message instanceof String) {
       return ((String) message).trim();
     }
     return "";
   }
-
-
 
 }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/programflow/ServiceB.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/programflow/ServiceB.java
@@ -1,6 +1,7 @@
 package com.ly.train.flower.common.sample.programflow;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceB implements Service {
 
@@ -10,7 +11,7 @@ public class ServiceB implements Service {
   /**
    * upper case service
    */
-  public Object process(Object message) {
+  public Object process(Object message, ServiceContext context) {
     if (message != null && message instanceof String) {
       MessageA ma = new MessageA();
       ma.setI(i++);

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/programflow/ServiceC.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/programflow/ServiceC.java
@@ -1,6 +1,7 @@
 package com.ly.train.flower.common.sample.programflow;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class ServiceC implements Service<MessageA> {
 
@@ -8,7 +9,7 @@ public class ServiceC implements Service<MessageA> {
   /**
    * print service
    */
-  public Object process(MessageA message) {
+  public Object process(MessageA message, ServiceContext context) {
     MessageA ma = (MessageA) message;
     System.out.println(ma.getS() + " I am " + ma.getI());
     return null;

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/textflow/Service1.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/textflow/Service1.java
@@ -1,13 +1,13 @@
 package com.ly.train.flower.common.sample.textflow;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class Service1 implements Service {
 
-
   @Override
-  public Object process(Object message) {
-    return ((Message1)message).getM2();
+  public Object process(Object message, ServiceContext context) {
+    return ((Message1) message).getM2();
   }
 
 }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/textflow/Service2.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/textflow/Service2.java
@@ -1,11 +1,12 @@
 package com.ly.train.flower.common.sample.textflow;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class Service2 implements Service<Message2> {
 
   @Override
-  public Object process(Message2 message) {
+  public Object process(Message2 message, ServiceContext context) {
     return message.getAge() + 1;
   }
 

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/textflow/Service3.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/textflow/Service3.java
@@ -1,11 +1,12 @@
 package com.ly.train.flower.common.sample.textflow;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 public class Service3 implements Service<Message2> {
 
   @Override
-  public Object process(Message2 message) {
+  public Object process(Message2 message, ServiceContext context) {
     return message.getName().toUpperCase();
   }
 

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/textflow/Service4.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/textflow/Service4.java
@@ -1,13 +1,14 @@
 package com.ly.train.flower.common.sample.textflow;
 
 import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 import java.util.Set;
 
 public class Service4 implements Service<Set> {
 
   @Override
-  public Object process(Set message) {
+  public Object process(Set message, ServiceContext context) {
     Message2 m = new Message2();
     for (Object o : message) {
 

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/FlowService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/FlowService.java
@@ -1,11 +1,12 @@
 package com.ly.train.flower.common.sample.web;
 
+import com.ly.train.flower.common.service.Complete;
 import com.ly.train.flower.common.service.Service;
 import com.ly.train.flower.common.service.containe.ServiceContext;
-import com.ly.train.flower.common.service.web.HttpComplete;
 import com.ly.train.flower.common.service.web.Flush;
+import com.ly.train.flower.common.service.web.HttpComplete;
 
-public class FlowService implements Service, HttpComplete, Flush {
+public class FlowService implements Service, HttpComplete, Flush, Complete {
 
   public FlowService() {
   }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/FlowService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/FlowService.java
@@ -1,13 +1,11 @@
 package com.ly.train.flower.common.sample.web;
 
-import com.ly.train.flower.common.service.AfterDelay;
-import com.ly.train.flower.common.service.HttpService;
-import com.ly.train.flower.common.service.web.Flush;
+import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 import com.ly.train.flower.common.service.web.Complete;
-import com.ly.train.flower.common.service.web.Web;
+import com.ly.train.flower.common.service.web.Flush;
 
-public class FlowService implements HttpService, Complete, Flush {
-
+public class FlowService implements Service, Complete, Flush {
 
   public FlowService() {
   }
@@ -16,9 +14,9 @@ public class FlowService implements HttpService, Complete, Flush {
   /**
    * trim service
    */
-  public Object process(Object message, Web web) throws Exception {
+  public Object process(Object message, ServiceContext context) throws Exception {
 
-    web.println(" - end:" + System.currentTimeMillis());
+    context.getWeb().println(" - end:" + System.currentTimeMillis());
     return "";
   }
 

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/FlowService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/FlowService.java
@@ -2,10 +2,10 @@ package com.ly.train.flower.common.sample.web;
 
 import com.ly.train.flower.common.service.Service;
 import com.ly.train.flower.common.service.containe.ServiceContext;
-import com.ly.train.flower.common.service.web.Complete;
+import com.ly.train.flower.common.service.web.HttpComplete;
 import com.ly.train.flower.common.service.web.Flush;
 
-public class FlowService implements Service, Complete, Flush {
+public class FlowService implements Service, HttpComplete, Flush {
 
   public FlowService() {
   }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/async/ServiceA.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/async/ServiceA.java
@@ -1,14 +1,14 @@
 package com.ly.train.flower.common.sample.web.async;
 
-import com.ly.train.flower.common.service.HttpService;
-import com.ly.train.flower.common.service.web.Web;
+import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
-public class ServiceA implements HttpService<String> {
+public class ServiceA implements Service<String> {
 
   @Override
-  public Object process(String message, Web web) throws Exception {
-    //id非Integer的时候会抛出一个异常
-    Integer result = Integer.valueOf(web.getParameter("id"));
+  public Object process(String message, ServiceContext context) throws Exception {
+    // id非Integer的时候会抛出一个异常
+    Integer result = Integer.valueOf(context.getWeb().getParameter("id"));
     return result;
   }
 

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/async/ServiceB.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/async/ServiceB.java
@@ -7,11 +7,11 @@ import com.alibaba.fastjson.JSONObject;
 import com.ly.train.flower.common.sample.web.dao.UserDao;
 import com.ly.train.flower.common.sample.web.mode.User;
 import com.ly.train.flower.common.service.containe.ServiceContext;
-import com.ly.train.flower.common.service.web.Complete;
+import com.ly.train.flower.common.service.web.HttpComplete;
 import com.ly.train.flower.common.service.web.Flush;
 
 @Service("serviceB")
-public class ServiceB implements com.ly.train.flower.common.service.Service<Integer>, Flush, Complete {
+public class ServiceB implements com.ly.train.flower.common.service.Service<Integer>, Flush, HttpComplete {
 
   @Autowired
   private UserDao userDao;

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/async/ServiceB.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/async/ServiceB.java
@@ -6,12 +6,13 @@ import org.springframework.stereotype.Service;
 import com.alibaba.fastjson.JSONObject;
 import com.ly.train.flower.common.sample.web.dao.UserDao;
 import com.ly.train.flower.common.sample.web.mode.User;
+import com.ly.train.flower.common.service.Complete;
 import com.ly.train.flower.common.service.containe.ServiceContext;
-import com.ly.train.flower.common.service.web.HttpComplete;
 import com.ly.train.flower.common.service.web.Flush;
 
 @Service("serviceB")
-public class ServiceB implements com.ly.train.flower.common.service.Service<Integer>, Flush, HttpComplete {
+public class ServiceB
+    implements com.ly.train.flower.common.service.Service<Integer>, Flush, Complete {
 
   @Autowired
   private UserDao userDao;

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/async/ServiceB.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/async/ServiceB.java
@@ -4,28 +4,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.alibaba.fastjson.JSONObject;
-import com.ly.train.flower.common.sample.web.mode.User;
 import com.ly.train.flower.common.sample.web.dao.UserDao;
-import com.ly.train.flower.common.service.HttpService;
+import com.ly.train.flower.common.sample.web.mode.User;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 import com.ly.train.flower.common.service.web.Complete;
 import com.ly.train.flower.common.service.web.Flush;
-import com.ly.train.flower.common.service.web.Web;
 
 @Service("serviceB")
-public class ServiceB implements HttpService<Integer>, Flush, Complete {
+public class ServiceB implements com.ly.train.flower.common.service.Service<Integer>, Flush, Complete {
 
   @Autowired
   private UserDao userDao;
 
   @Override
-  public Object process(Integer message, Web web) throws Exception {
+  public Object process(Integer message, ServiceContext context) throws Exception {
     User user = userDao.findUser(message);
     if (user == null) {
-      web.complete();
+      context.getWeb().complete();
       throw new NullPointerException("user:" + message + " is not found.");
     }
     String result = JSONObject.toJSONString(user);
-    web.print(result);
+    context.getWeb().print(result);
     return null;
   }
 

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/BeginService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/BeginService.java
@@ -1,17 +1,17 @@
 package com.ly.train.flower.common.sample.web.forktest.service;
 
-import com.ly.train.flower.common.service.HttpService;
-import com.ly.train.flower.common.service.web.Web;
+import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 /**
  * @Author: fengyu.zhang
  * @Date: 2019/2/24 14:33
  */
-public class BeginService implements HttpService<String> {
+public class BeginService implements Service<String> {
 
     @Override
-    public Object process(String message, Web web) throws Exception {
-        Integer result = Integer.valueOf(web.getParameter("id"));
+    public Object process(String message, ServiceContext context) throws Exception {
+        Integer result = Integer.valueOf(context.getWeb().getParameter("id"));
         return result;
     }
 }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/GoodsService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/GoodsService.java
@@ -1,25 +1,25 @@
 package com.ly.train.flower.common.sample.web.forktest.service;
 
-import com.ly.train.flower.common.sample.web.dao.GoodsDao;
-import com.ly.train.flower.common.service.HttpService;
-import com.ly.train.flower.common.service.web.Web;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.ly.train.flower.common.sample.web.dao.GoodsDao;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 /**
  * @Author: fengyu.zhang
  * @Date: 2019/2/24 17:16
  */
 @Service("GoodsService")
-public class GoodsService implements HttpService<Integer> {
+public class GoodsService implements com.ly.train.flower.common.service.Service<Integer> {
     @Autowired
     private GoodsDao goodsDao;
 
     @Override
-    public Object process(Integer message, Web web) throws Exception {
+    public Object process(Integer message, ServiceContext context) throws Exception {
         List<Integer> list = goodsDao.findGoodsIdForRecommend(message);
         return list == null? new ArrayList<Integer>():list;
     }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/OrderService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/OrderService.java
@@ -1,26 +1,26 @@
 package com.ly.train.flower.common.sample.web.forktest.service;
 
-import com.ly.train.flower.common.sample.web.dao.OrderDao;
-import com.ly.train.flower.common.sample.web.mode.Order;
-import com.ly.train.flower.common.service.HttpService;
-import com.ly.train.flower.common.service.web.Web;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.ly.train.flower.common.sample.web.dao.OrderDao;
+import com.ly.train.flower.common.sample.web.mode.Order;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 /**
  * @Author: fengyu.zhang
  * @Date: 2019/2/24 17:16
  */
 @Service("OrderService")
-public class OrderService implements HttpService<Integer> {
+public class OrderService implements com.ly.train.flower.common.service.Service<Integer> {
     @Autowired
     private OrderDao orderDao;
 
     @Override
-    public Object process(Integer message, Web web) throws Exception {
+    public Object process(Integer message, ServiceContext context) throws Exception {
         List<Order> orders = orderDao.findByCustomerId(message);
         return orders == null ? new ArrayList<Order>() : orders;
     }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/ReturnService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/ReturnService.java
@@ -3,8 +3,8 @@ package com.ly.train.flower.common.sample.web.forktest.service;
 import java.util.Set;
 
 import com.alibaba.fastjson.JSONObject;
+import com.ly.train.flower.common.service.Complete;
 import com.ly.train.flower.common.service.containe.ServiceContext;
-import com.ly.train.flower.common.service.web.HttpComplete;
 import com.ly.train.flower.common.service.web.Flush;
 
 /**
@@ -12,7 +12,7 @@ import com.ly.train.flower.common.service.web.Flush;
  * @Date: 2019/2/24 13:23
  */
 public class ReturnService
-    implements com.ly.train.flower.common.service.Service<Set>, Flush, HttpComplete {
+    implements com.ly.train.flower.common.service.Service<Set>, Flush, Complete {
 
   @Override
   public Object process(Set message, ServiceContext context) throws Exception {

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/ReturnService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/ReturnService.java
@@ -4,7 +4,7 @@ import java.util.Set;
 
 import com.alibaba.fastjson.JSONObject;
 import com.ly.train.flower.common.service.containe.ServiceContext;
-import com.ly.train.flower.common.service.web.Complete;
+import com.ly.train.flower.common.service.web.HttpComplete;
 import com.ly.train.flower.common.service.web.Flush;
 
 /**
@@ -12,7 +12,7 @@ import com.ly.train.flower.common.service.web.Flush;
  * @Date: 2019/2/24 13:23
  */
 public class ReturnService
-    implements com.ly.train.flower.common.service.Service<Set>, Flush, Complete {
+    implements com.ly.train.flower.common.service.Service<Set>, Flush, HttpComplete {
 
   @Override
   public Object process(Set message, ServiceContext context) throws Exception {

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/ReturnService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/ReturnService.java
@@ -1,22 +1,22 @@
 package com.ly.train.flower.common.sample.web.forktest.service;
 
+import java.util.Set;
+
 import com.alibaba.fastjson.JSONObject;
-import com.ly.train.flower.common.service.HttpService;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 import com.ly.train.flower.common.service.web.Complete;
 import com.ly.train.flower.common.service.web.Flush;
-import com.ly.train.flower.common.service.web.Web;
-
-import java.util.Set;
 
 /**
  * @Author: fengyu.zhang
  * @Date: 2019/2/24 13:23
  */
-public class ReturnService implements HttpService<Set>, Flush, Complete {
+public class ReturnService
+    implements com.ly.train.flower.common.service.Service<Set>, Flush, Complete {
 
-    @Override
-    public Object process(Set message, Web web) throws Exception {
-        web.print(JSONObject.toJSONString(message));
-        return null;
-    }
+  @Override
+  public Object process(Set message, ServiceContext context) throws Exception {
+    context.getWeb().print(JSONObject.toJSONString(message));
+    return null;
+  }
 }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/UserService.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/web/forktest/service/UserService.java
@@ -1,11 +1,11 @@
 package com.ly.train.flower.common.sample.web.forktest.service;
 
-import com.ly.train.flower.common.sample.web.dao.UserDao;
-import com.ly.train.flower.common.sample.web.mode.User;
-import com.ly.train.flower.common.service.HttpService;
-import com.ly.train.flower.common.service.web.Web;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import com.ly.train.flower.common.sample.web.dao.UserDao;
+import com.ly.train.flower.common.sample.web.mode.User;
+import com.ly.train.flower.common.service.containe.ServiceContext;
 
 /**
  * @Author: fengyu.zhang
@@ -13,12 +13,12 @@ import org.springframework.stereotype.Service;
  */
 
 @Service("UserService")
-public class UserService implements HttpService<Integer> {
+public class UserService implements com.ly.train.flower.common.service.Service<Integer> {
     @Autowired
     private UserDao userDao;
 
     @Override
-    public Object process(Integer message, Web web) throws Exception {
+    public Object process(Integer message, ServiceContext context) throws Exception {
         User user = userDao.findUser(message);
         return user == null ? new User():user;
     }


### PR DESCRIPTION
调整Sevice process接口为process(Integer message, ServiceContext context)
增加ServiceContext参数，使用者可以利用context在不同Service之间传递数据。
`context.put("hello", new World());`
`context.get("hello"); `


删除原HttpService接口，统一使用Service接口，原HttpService接口的web通过以下方式获得。
`context.getWeb()`

流程最后的service需要implements Compele，框架会清理context，否则会引起内存泄漏。

Service实现HttpComplete接口只会关闭web，实现Complete会同时关闭web和清除context。