### PR TITLE
flower增加支持springboot

### DIFF
--- a/flower.sample/pom.xml
+++ b/flower.sample/pom.xml
@@ -19,11 +19,18 @@
 			<artifactId>junit</artifactId>
 			<version>3.8.1</version>
 		</dependency>
+
 		<dependency>
 			<groupId>com.ly.train</groupId>
 			<artifactId>flower.common</artifactId>
 			<version>0.1</version>
 		</dependency>
+		<dependency>
+			<groupId>com.ly.train</groupId>
+			<artifactId>flower.web</artifactId>
+			<version>0.1</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
@@ -99,17 +106,28 @@
 			<artifactId>akka-slf4j_2.12</artifactId>
 			<version>2.5.21</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<version>2.1.3.RELEASE</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
+				<version>3.4.6</version>
 			</plugin>
 			<plugin>
 				<groupId>io.gatling</groupId>
 				<artifactId>gatling-maven-plugin</artifactId>
+				<version>3.0.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>2.1.3.RELEASE</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/DemoApplication.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/DemoApplication.java
@@ -1,0 +1,12 @@
+package com.ly.train.flower.common.sample.springboot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@SpringBootApplication
+public class DemoApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(DemoApplication.class, args);
+  }
+}

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/Index2Controller.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/Index2Controller.java
@@ -1,0 +1,47 @@
+package com.ly.train.flower.common.sample.springboot;
+
+
+import com.ly.train.flower.common.actor.ServiceFacade;
+import com.ly.train.flower.common.actor.ServiceRouter;
+import com.ly.train.flower.common.service.ServiceFlow;
+import com.ly.train.flower.common.service.containe.ServiceFactory;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+public class Index2Controller {
+  static final long serialVersionUID = 1L;
+  ServiceRouter serviceRouter;
+
+  public Index2Controller() {
+    buildServiceEnv();
+    serviceRouter = ServiceFacade.buildServiceRouter("async", "serviceA", 400);
+  }
+
+  @RequestMapping("/index2")
+  public void index(HttpServletRequest req) {
+    AsyncContext context = req.startAsync();
+    asyncExe(context);
+  }
+
+  private void asyncExe(AsyncContext ctx) {
+    try {
+      serviceRouter.asyncCallService(null, ctx);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void buildServiceEnv() {
+    ServiceFactory.registerService("serviceA",
+        "com.ly.train.flower.common.sample.springboot.ServiceA");
+    ServiceFactory.registerService("serviceB",
+        "com.ly.train.flower.common.sample.springboot.ServiceB");
+
+    ServiceFlow.buildFlow("async", "serviceA", "serviceB");
+
+  }
+}

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/IndexController.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/IndexController.java
@@ -1,0 +1,49 @@
+package com.ly.train.flower.common.sample.springboot;
+
+import com.ly.train.flower.common.actor.ServiceFacade;
+import com.ly.train.flower.common.actor.ServiceRouter;
+import com.ly.train.flower.common.service.ServiceFlow;
+import com.ly.train.flower.common.service.containe.ServiceFactory;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.web.bind.annotation.RequestMethod.*;
+
+@RestController
+public class IndexController {
+  static final long serialVersionUID = 1L;
+  ServiceRouter sr;
+
+  public IndexController() {
+    buildServiceEnv();
+    sr = ServiceFacade.buildServiceRouter("async", "serviceA", 400);
+  }
+
+  @RequestMapping(value = "/", method = POST)
+  public void index(HttpServletRequest req) {
+    AsyncContext context = req.startAsync();
+    asyncExe(context);
+  }
+
+  private void asyncExe(AsyncContext ctx) {
+    try {
+      sr.asyncCallService(null, ctx);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void buildServiceEnv() {
+    ServiceFactory.registerService("serviceA",
+        "com.ly.train.flower.common.sample.springboot.ServiceA");
+    ServiceFactory.registerService("serviceB",
+        "com.ly.train.flower.common.sample.springboot.ServiceB");
+
+    ServiceFlow.buildFlow("async", "serviceA", "serviceB");
+
+  }
+}

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceA.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceA.java
@@ -1,0 +1,35 @@
+package com.ly.train.flower.common.sample.springboot;
+
+import com.ly.flower.web.springboot.InitController;
+import com.ly.flower.web.springboot.annotation.BindController;
+import com.ly.train.flower.common.actor.ServiceFacade;
+import com.ly.train.flower.common.actor.ServiceRouter;
+import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.ServiceFlow;
+import com.ly.train.flower.common.service.containe.ServiceContext;
+import com.ly.train.flower.common.service.containe.ServiceFactory;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@BindController(path = "/ServiceA", method= RequestMethod.GET)
+public class ServiceA implements Service<String>, InitController {
+  @Override
+  public Object process(String message, ServiceContext context) throws Exception {
+    context.getWeb().println("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    return 1111111;
+  }
+
+  @Override
+  public Object init() {
+    buildServiceEnv();
+    return ServiceFacade.buildServiceRouter("async", "serviceA", 400);
+  }
+
+  private static void buildServiceEnv() {
+    ServiceFactory.registerService("serviceA",
+        "com.ly.train.flower.common.sample.springboot.ServiceA");
+    ServiceFactory.registerService("serviceB",
+        "com.ly.train.flower.common.sample.springboot.ServiceB");
+
+    ServiceFlow.buildFlow("async", "serviceA", "serviceB");
+  }
+}

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceA.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceA.java
@@ -19,7 +19,7 @@ public class ServiceA implements Service<String>, InitController {
   }
 
   @Override
-  public Object init() {
+  public ServiceRouter init() {
     buildServiceEnv();
     return ServiceFacade.buildServiceRouter("async", "serviceA", 400);
   }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceB.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceB.java
@@ -1,0 +1,16 @@
+package com.ly.train.flower.common.sample.springboot;
+
+import com.ly.flower.web.springboot.annotation.BindController;
+import com.ly.train.flower.common.service.Complete;
+import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.containe.ServiceContext;
+import com.ly.train.flower.common.service.web.Flush;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+public class ServiceB implements Service<Integer>, Flush, Complete {
+  @Override
+  public Object process(Integer message, ServiceContext context) throws Exception {
+    context.getWeb().println("ServiceB:" + String.valueOf(message));
+    return null;
+  }
+}

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceC.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceC.java
@@ -19,7 +19,7 @@ public class ServiceC implements Service<String>, InitController {
   }
 
   @Override
-  public Object init() {
+  public ServiceRouter init() {
     buildServiceEnv();
     return ServiceFacade.buildServiceRouter("async", "serviceC", 400);
   }

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceC.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceC.java
@@ -1,0 +1,35 @@
+package com.ly.train.flower.common.sample.springboot;
+
+import com.ly.flower.web.springboot.InitController;
+import com.ly.flower.web.springboot.annotation.BindController;
+import com.ly.train.flower.common.actor.ServiceFacade;
+import com.ly.train.flower.common.actor.ServiceRouter;
+import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.ServiceFlow;
+import com.ly.train.flower.common.service.containe.ServiceContext;
+import com.ly.train.flower.common.service.containe.ServiceFactory;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@BindController(path = "/ServiceC", method= RequestMethod.POST)
+public class ServiceC implements Service<String>, InitController {
+  @Override
+  public Object process(String message, ServiceContext context) throws Exception {
+    context.getWeb().println("CCCCCCCCCCCCCCCCCCCCCCCCCCc");
+    return 333333;
+  }
+
+  @Override
+  public Object init() {
+    buildServiceEnv();
+    return ServiceFacade.buildServiceRouter("async", "serviceC", 400);
+  }
+
+  private static void buildServiceEnv() {
+    ServiceFactory.registerService("serviceC",
+        "com.ly.train.flower.common.sample.springboot.ServiceC");
+    ServiceFactory.registerService("serviceB",
+        "com.ly.train.flower.common.sample.springboot.ServiceB");
+
+    ServiceFlow.buildFlow("async", "serviceC", "serviceB");
+  }
+}

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceD.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/ServiceD.java
@@ -1,0 +1,36 @@
+package com.ly.train.flower.common.sample.springboot;
+
+import com.ly.flower.web.springboot.InitController;
+import com.ly.flower.web.springboot.annotation.BindController;
+import com.ly.train.flower.common.actor.ServiceFacade;
+import com.ly.train.flower.common.actor.ServiceRouter;
+import com.ly.train.flower.common.service.Service;
+import com.ly.train.flower.common.service.ServiceFlow;
+import com.ly.train.flower.common.service.containe.ServiceContext;
+import com.ly.train.flower.common.service.containe.ServiceFactory;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@BindController(path = "/ServiceD", method = RequestMethod.GET, paramClass = User.class)
+public class ServiceD implements Service<User>, InitController {
+
+    @Override
+    public ServiceRouter init() {
+        buildServiceEnv();
+        return ServiceFacade.buildServiceRouter("async", "serviceD", 400);
+    }
+
+    private static void buildServiceEnv() {
+        ServiceFactory.registerService("serviceD",
+                "com.ly.train.flower.common.sample.springboot.ServiceD");
+        ServiceFactory.registerService("serviceB",
+                "com.ly.train.flower.common.sample.springboot.ServiceB");
+
+        ServiceFlow.buildFlow("async", "serviceD", "serviceB");
+    }
+
+    @Override
+    public Object process(User message, ServiceContext context) throws Throwable {
+        context.getWeb().println("User:" + message.getName());
+        return message.getId();
+    }
+}

--- a/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/User.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot/User.java
@@ -1,0 +1,27 @@
+package com.ly.train.flower.common.sample.springboot;
+
+public class User {
+    private String name;
+    private Integer id;
+
+    public User(String name, Integer id) {
+        this.name = name;
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+}

--- a/flower.web/pom.xml
+++ b/flower.web/pom.xml
@@ -24,6 +24,12 @@
             <artifactId>spring-web</artifactId>
             <version>5.1.5.RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>com.ly.train</groupId>
+            <artifactId>flower.common</artifactId>
+            <version>0.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/flower.web/pom.xml
+++ b/flower.web/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.ly.train</groupId>
+        <artifactId>flower</artifactId>
+        <version>0.1</version>
+    </parent>
+    <groupId>com.ly.train</groupId>
+    <artifactId>flower.web</artifactId>
+    <version>0.1</version>
+    <name>flower.web</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity</artifactId>
+            <version>1.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.1.5.RELEASE</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <verbose>true</verbose>
+                    <compilerVersion>1.8</compilerVersion>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flower.web/src/main/java/com/ly/flower/web/springboot/InitController.java
+++ b/flower.web/src/main/java/com/ly/flower/web/springboot/InitController.java
@@ -1,5 +1,7 @@
 package com.ly.flower.web.springboot;
 
+import com.ly.train.flower.common.actor.ServiceRouter;
+
 public interface InitController {
-  public Object init();
+  public ServiceRouter init();
 }

--- a/flower.web/src/main/java/com/ly/flower/web/springboot/InitController.java
+++ b/flower.web/src/main/java/com/ly/flower/web/springboot/InitController.java
@@ -1,0 +1,5 @@
+package com.ly.flower.web.springboot;
+
+public interface InitController {
+  public Object init();
+}

--- a/flower.web/src/main/java/com/ly/flower/web/springboot/annotation/BindController.java
+++ b/flower.web/src/main/java/com/ly/flower/web/springboot/annotation/BindController.java
@@ -7,4 +7,5 @@ public @interface BindController {
   String type() default "@RequestMapping";
   String path();
   RequestMethod method();
+  Class<?> paramClass() default Void.class;
 }

--- a/flower.web/src/main/java/com/ly/flower/web/springboot/annotation/BindController.java
+++ b/flower.web/src/main/java/com/ly/flower/web/springboot/annotation/BindController.java
@@ -1,0 +1,10 @@
+package com.ly.flower.web.springboot.annotation;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+
+public @interface BindController {
+  String value() default "@RestController";
+  String type() default "@RequestMapping";
+  String path();
+  RequestMethod method();
+}

--- a/flower.web/src/main/java/com/ly/flower/web/springboot/processors/BindProcessor.java
+++ b/flower.web/src/main/java/com/ly/flower/web/springboot/processors/BindProcessor.java
@@ -1,0 +1,95 @@
+package com.ly.flower.web.springboot.processors;
+
+import com.ly.flower.web.springboot.annotation.BindController;
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.io.Writer;
+import java.net.URL;
+import java.util.Properties;
+import java.util.Set;
+
+@SupportedAnnotationTypes("com.ly.flower.web.springboot.annotation.BindController")
+@SupportedSourceVersion(SourceVersion.RELEASE_6)
+public class BindProcessor extends AbstractProcessor {
+  private static final String TAG = "[ " + BindProcessor.class.getSimpleName() + " ]:";
+
+  @Override
+  public Set<String> getSupportedAnnotationTypes() {
+    return super.getSupportedAnnotationTypes();
+  }
+  @Override
+  public boolean process(Set<? extends TypeElement> set, RoundEnvironment roundEnvironment) {
+    for (Element element : roundEnvironment.getElementsAnnotatedWith(BindController.class)) {
+      if (element instanceof  TypeElement) {
+        TypeElement classElement = (TypeElement)element;
+        PackageElement packageElement = (PackageElement) classElement.getEnclosingElement();
+
+        String fullClassName = classElement.getQualifiedName().toString();
+        String className = classElement.getSimpleName().toString();
+        String packageName = packageElement.getQualifiedName().toString();
+
+        BindController bindController = classElement.getAnnotation(BindController.class);
+
+        String BindControllerValue = bindController.value();
+        String BindControllerType = bindController.type();
+        String BindControllerPath = bindController.path();
+        RequestMethod BindControllerMethod = bindController.method();
+
+        loge(fullClassName + "\n" + className + "\n" + packageName + "\n" + BindControllerValue + " " + BindControllerType + " " + BindControllerPath + " " + BindControllerMethod.toString());
+        try {
+          Properties props = new Properties();
+          URL url = this.getClass().getClassLoader().getResource("velocity.properties");
+          props.load(url.openStream());
+
+          VelocityEngine velocityEngine = new VelocityEngine(props);
+          velocityEngine.init();
+
+          VelocityContext velocityContext = new VelocityContext();
+          velocityContext.put("packageName", packageName);
+          velocityContext.put("className", className);
+          velocityContext.put("BindControllerValue", BindControllerValue);
+          velocityContext.put("BindControllerType", BindControllerType);
+          velocityContext.put("BindControllerPath", BindControllerPath);
+          velocityContext.put("BindControllerMethod", BindControllerMethod);
+
+          Template velocityEngineTemplate = velocityEngine.getTemplate("BindController.vm");
+
+          JavaFileObject jfo = processingEnv.getFiler().createSourceFile(
+              fullClassName + "Controller");
+
+          loge("creating source file: " + jfo.toUri());
+
+          Writer writer = jfo.openWriter();
+
+          loge("applying velocity template: " + velocityEngineTemplate.getName());
+
+          velocityEngineTemplate.merge(velocityContext, writer);
+
+          writer.close();
+
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+
+
+      }
+
+    }
+    return true;
+  }
+
+  private void loge(String msg) {
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, TAG + msg);
+  }
+}

--- a/flower.web/src/main/resources/BindController.vm
+++ b/flower.web/src/main/resources/BindController.vm
@@ -1,0 +1,27 @@
+package ${packageName};
+
+import com.ly.train.flower.common.actor.ServiceRouter;
+import org.springframework.web.bind.annotation.*;
+import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import static org.springframework.web.bind.annotation.RequestMethod.*;
+
+${BindControllerValue}
+public class ${className}Controller {
+    ServiceRouter serviceRouter = null;
+    public ${className}Controller() {
+        serviceRouter = (ServiceRouter)new ${className}().init();
+    }
+
+    ${BindControllerType}(value = "${BindControllerPath}", method = ${BindControllerMethod})
+    public void path(HttpServletRequest request) {
+        AsyncContext context = request.startAsync();
+        try {
+            serviceRouter.asyncCallService(null, context);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/flower.web/src/main/resources/BindObjectController.vm
+++ b/flower.web/src/main/resources/BindObjectController.vm
@@ -16,10 +16,10 @@ public class ${className}Controller {
     }
 
     ${BindControllerType}(value = "${BindControllerPath}", method = ${BindControllerMethod})
-    public void path(HttpServletRequest request) {
+    public void path(${BingControllerClass} obj, HttpServletRequest request) {
         AsyncContext context = request.startAsync();
         try {
-            serviceRouter.asyncCallService(null, context);
+            serviceRouter.asyncCallService(obj, context);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/flower.web/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/flower.web/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.ly.flower.web.springboot.processors.BindProcessor

--- a/flower.web/src/main/resources/velocity.properties
+++ b/flower.web/src/main/resources/velocity.properties
@@ -1,0 +1,3 @@
+runtime.log.logsystem.class = org.apache.velocity.runtime.log.SystemLogChute
+resource.loader = classpath
+classpath.resource.loader.class = org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader

--- a/pom.xml
+++ b/pom.xml
@@ -31,16 +31,18 @@
 		<module>flower.common</module>
 		<module>flower.center</module>
 		<module>flower.sample</module>
+		<module>flower.web</module>
 		<module>flower.assembly</module>
 	</modules>
 
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
 				<configuration>
 					<compilerVersion>1.8</compilerVersion>
-					<fork>true</fork>
 					<source>1.8</source>
 					<target>1.8</target>
 				</configuration>


### PR DESCRIPTION
1. flower.web通过注解的方式在编译时生成springboot需要的Controller
2. flower.sample/src/main/java/com/ly/train/flower/common/sample/springboot是测试例子
3. mvn install后, 在flower.sample/target/generated-sources/annotations/com/ly/train/flower/common/sample/springboot目录下可以看到自动生成的源码
4. ServiceA 是GET的例子
5. ServiceC 是POST的例子
6. ServiceD 是绑定序列化参数的例子