### PR TITLE
Fix CondtionServiceSample to be runnable 

### DIFF
--- a/docs/program_guide.md
+++ b/docs/program_guide.md
@@ -181,9 +181,9 @@ ConditionService是一个通用的消息分发服务，
 serviceCondition的服务注册方法为
 ```
     ServiceFactory.registerService("serviceCondition",
-        "com.ly.train.flower.common.service.ConditionService;serviceF,serviceG");
+        "com.ly.train.flower.core.service.impl.ConditionService;serviceF,serviceG");
 ```
-com.ly.train.flower.common.service.ConditionService为框架内置服务
+com.ly.train.flower.core.service.impl.ConditionService 为框架内置服务
 
 ```
 public class ServiceE implements Service {

--- a/flower.sample/src/main/java/com/ly/train/flower/sample/AllTests.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/sample/AllTests.java
@@ -18,6 +18,7 @@
  */
 package com.ly.train.flower.sample;
 
+import com.ly.train.flower.sample.condition.ConditionServiceSample;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -27,7 +28,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * 
  */
 @RunWith(Suite.class)
-@SuiteClasses({com.ly.train.flower.sample.condition.CondtionServiceSample.class,
+@SuiteClasses({ConditionServiceSample.class,
     com.ly.train.flower.sample.programflow.Sample.class, com.ly.train.flower.sample.supervisor.Sample.class,
     com.ly.train.flower.sample.supervisor.BatchSample.class, com.ly.train.flower.sample.textflow.BatchSample.class,
     com.ly.train.flower.sample.textflow.Sample.class, com.ly.train.flower.sample.textflow.ServiceRouterSample.class})

--- a/flower.sample/src/main/java/com/ly/train/flower/sample/condition/ConditionServiceSample.java
+++ b/flower.sample/src/main/java/com/ly/train/flower/sample/condition/ConditionServiceSample.java
@@ -15,6 +15,7 @@
  */
 package com.ly.train.flower.sample.condition;
 
+import com.ly.train.flower.core.service.impl.ConditionService;
 import org.junit.Test;
 import com.ly.train.flower.core.service.container.FlowerFactory;
 import com.ly.train.flower.core.service.container.ServiceFactory;
@@ -28,7 +29,7 @@ import com.ly.train.flower.sample.condition.service.ServiceE;
 import com.ly.train.flower.sample.condition.service.ServiceF;
 import com.ly.train.flower.sample.condition.service.ServiceG;
 
-public class CondtionServiceSample extends TestBase {
+public class ConditionServiceSample extends TestBase {
 
   private String flowName = "conditionSample";
 
@@ -49,7 +50,7 @@ public class CondtionServiceSample extends TestBase {
     serviceFactory.registerService("serviceF", ServiceF.class);
     serviceFactory.registerService("serviceG", ServiceG.class);
     serviceFactory.registerService("serviceCondition",
-        "com.ly.train.flower.common.service.impl.ConditionService;serviceF,serviceG");
+        ConditionService.class.getCanonicalName() + ";serviceF,serviceG");
 
     ServiceFlow serviceFlow = ServiceFlow.getOrCreate(flowName, serviceFactory);
 


### PR DESCRIPTION
## Brief Description
 -   fix `com.ly.train.flower.common.service.impl.ConditionService` to `com.ly.train.flower.core.service.impl.ConditionService` because package renamed via the commit a2018457
 -  fix typo: `CondtionServiceSample` to `ConditionServiceSample`
