### PR TITLE
bugfix:当Service不是继承一个基类时能够获取到准确的参数类型和返回值类型

### DIFF
--- a/flower.common/src/main/java/com/ly/train/flower/common/util/TypeParameterUtil.java
+++ b/flower.common/src/main/java/com/ly/train/flower/common/util/TypeParameterUtil.java
@@ -25,6 +25,12 @@ import com.ly.train.flower.common.core.service.Service;
  */
 public class TypeParameterUtil {
 
+  /**
+   * key is paramType Class, value is the resultType Class
+   * 
+   * @param serviceClass service Class
+   * @return {@link Pair}
+   */
   public static Pair<Class<?>, Class<?>> getServiceClassParam(Class<?> serviceClass) {
     Type[] paramTypes = null;
     Type[] types = serviceClass.getGenericInterfaces();

--- a/flower.core/src/main/java/com/ly/train/flower/core/service/container/ServiceLoader.java
+++ b/flower.core/src/main/java/com/ly/train/flower/core/service/container/ServiceLoader.java
@@ -37,6 +37,7 @@ import com.ly.train.flower.common.util.Constant;
 import com.ly.train.flower.common.util.FileUtil;
 import com.ly.train.flower.common.util.Pair;
 import com.ly.train.flower.common.util.StringUtil;
+import com.ly.train.flower.common.util.TypeParameterUtil;
 import com.ly.train.flower.core.service.container.util.ServiceLoaderUtil;
 
 public class ServiceLoader extends AbstractInit {
@@ -224,8 +225,10 @@ public class ServiceLoader extends AbstractInit {
         serviceMeta.setFlowerType(FlowerServiceUtil.getFlowerType(serviceClass));
         serviceMeta.setInnerAggregateService(Constant.AGGREGATE_SERVICE_NAME.equals(serviceClass.getName()));
         serviceMeta.setTimeout(FlowerServiceUtil.getTimeout(serviceClass));
-        serviceMeta.setParamType(processMethod.getParameterTypes()[0].getName());
-        serviceMeta.setResultType(processMethod.getReturnType().getName());
+
+        Pair<Class<?>, Class<?>> paramAndResultType = TypeParameterUtil.getServiceClassParam(serviceClass);
+        serviceMeta.setParamType(paramAndResultType.getKey().getName());
+        serviceMeta.setResultType(paramAndResultType.getValue().getName());
         if (StringUtil.isNotBlank(config)) {
           String[] tt = config.split(";");
           if (tt.length > 1) {

--- a/flower.core/src/test/java/com/ly/train/flower/core/service/container/ServiceLoaderTest.java
+++ b/flower.core/src/test/java/com/ly/train/flower/core/service/container/ServiceLoaderTest.java
@@ -40,11 +40,20 @@ public class ServiceLoaderTest {
   }
 
   @Test
-  public void testLoadServiceMeta2() {
+  public void testLoadServiceMetaAndParamTypeFromSuperclass() {
     serviceLoader.registerServiceType(SuperService.class.getName(), SuperService.class);
     MethodProxy methodProxy = serviceLoader.loadService(SuperService.class.getName());
     Assert.assertEquals(true, methodProxy.isCompleted());
     ServiceMeta serviceMeta = serviceLoader.loadServiceMeta(SuperService.class.getName());
+    Assert.assertEquals(String.class.getName(), serviceMeta.getParamType());
+  }
+
+  @Test
+  public void testLoadServiceMetaAndParamTypeFromSuperclass2() {
+    serviceLoader.registerServiceType(SuperService2.class.getName(), SuperService2.class);
+    MethodProxy methodProxy = serviceLoader.loadService(SuperService2.class.getName());
+    Assert.assertEquals(false, methodProxy.isCompleted());
+    ServiceMeta serviceMeta = serviceLoader.loadServiceMeta(SuperService2.class.getName());
     Assert.assertEquals(Object.class.getName(), serviceMeta.getParamType());
   }
 
@@ -66,9 +75,19 @@ class SuperService extends AbstractService<String, String> implements HttpComple
   public String doProcess(String message, ServiceContext context) throws Throwable {
     return null;
   }
+}
+
+
+class BaseService implements Service<String, Object> {
 
   @Override
-  public void onError(String param, ServiceContext context, Throwable throwable) {
-    super.onError(param, context, throwable);
+  public Object process(String message, ServiceContext context) throws Throwable {
+    return null;
   }
+
+}
+
+
+class SuperService2 extends BaseService {
+
 }


### PR DESCRIPTION
## Brief Description
当Service不是继承一个基类时能够获取到准确的参数类型和返回值类型

## Feature 
test code
```

  @Test
  public void testLoadServiceMetaAndParamTypeFromSuperclass() {
    serviceLoader.registerServiceType(SuperService.class.getName(), SuperService.class);
    MethodProxy methodProxy = serviceLoader.loadService(SuperService.class.getName());
    Assert.assertEquals(true, methodProxy.isCompleted());
    ServiceMeta serviceMeta = serviceLoader.loadServiceMeta(SuperService.class.getName());
    Assert.assertEquals(String.class.getName(), serviceMeta.getParamType());
  }
```

SuperService.java
```

class SuperService extends AbstractService<String, String> implements HttpComplete {
  @Override
  public String doProcess(String message, ServiceContext context) throws Throwable {
    return null;
  }
}
```

and test passed.

