### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
 install: true
 
 script:
-  - travis_wait 30 ./mvnw clean install -DskipTests=true -Dcheckstyle.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -q -e
-  - travis_wait 30 ./mvnw cobertura:cobertura -DskipTests=true -Dmaven.javadoc.skip=true -q -e
+  - ./mvnw clean install -DskipTests=true -Dcheckstyle.skip=false -Drat.skip=false -Dmaven.javadoc.skip=true -q -e
+  - ./mvnw cobertura:cobertura -DskipTests=true -Dmaven.javadoc.skip=true -q -e
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
