### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 11.0.0.beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <github.repo>flower</github.repo>
         <java.version>1.8</java.version>
         <javassist.version>3.24.1-GA</javassist.version>
-        <jetty.version>10.0.10</jetty.version>
+        <jetty.version>11.0.0.beta3</jetty.version>
         <jmeter.version>5.1.1</jmeter.version>
         <junit.version>4.13.1</junit.version>
         <license-maven-plugin.version>3.0</license-maven-plugin.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 10.0.10
- [CVE-2022-2191](https://www.oscs1024.com/hd/CVE-2022-2191)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 10.0.10 to 11.0.0.beta3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS